### PR TITLE
Browsersync reload optimization

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,13 +90,14 @@ var paths = {
   }
 };
 gulp.task('stylus', function () {
-  gulp.src('./to_generate/stylus/main.styl')
+  return gulp.src('./to_generate/stylus/main.styl')
     .pipe(sourcemaps.init())
       .pipe(stylus({
         compress: true
       }))
     .pipe(sourcemaps.write())
-    .pipe(gulp.dest('./generated/assets/stylesheets/'));
+    .pipe(gulp.dest('./generated/assets/stylesheets/'))
+    .pipe(browserSync.stream());
 });
 gulp.task('watch:stylus', function () {
   gulp.watch(paths.stylus.src, ['stylus']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,12 +20,15 @@ gulp.task('clean', function(cb) {
 // Browser-Sync
 gulp.task('browser-sync', function() {
     browserSync.init({
+        reloadDelay: 500,
+        reloadDebounce: 500,
         server: {
             baseDir: './generated'
-        },
-        watchOptions: {
-          debounceDelay: 2000
         }
+    });
+
+    browserSync.watch(['generated/*.html'], function (event, file) {
+        browserSync.reload('generated/*.html');
     });
 });
 gulp.task('reload', function () {
@@ -42,7 +45,8 @@ gulp.task('imagemin', function() {
       svgoPlugins: [{removeViewBox: false}],
       use: [pngquant()]
     }))
-    .pipe(gulp.dest('./generated/assets/images/'));
+    .pipe(gulp.dest('./generated/assets/images/'))
+    .pipe(browserSync.stream());
 });
 
 //////////////////////////////////////////////////////////////////
@@ -65,15 +69,38 @@ gulp.task('watch:webpack', function() {
         filename: 'bundle.js'
       }
     }))
-    .pipe(gulp.dest('./generated/assets/javascript/'));
+    .pipe(gulp.dest('./generated/assets/javascript/'))
+    .pipe(browserSync.stream());
 });
 
 //////////////////////////////////////////////////////////////////
 // baked
+// Because we are handling js, stylus, and images ourselves, and we want to reload the page only when
+// baked is done loading, we must tell baked to ignore the js, css, and image files. This will allow us to
+// appropriately reload only when each of the different filetypes are changed using browserSync.stream for those
+// tasks, and a browserSync.watch task on html files (the only thing being handled by baked.js).
+
+  // baked.js currently has a bug where command line options are overriding options passed via
+  // the baked.init() method. So we have to fix that by faking the command line arguments like below.
+  // Please see https://github.com/prismicio/baked.js/issues/26 for more information.
+  process.argv.push('--ignore');
+  process.argv.push('js/*');
+  process.argv.push('--ignore');
+  process.argv.push('images/*');
+  process.argv.push('--ignore');
+  process.argv.push('stylus/*');
 
   // Load and get the baked configuration
   // in order to use srcDir and dstDir
-  var config = baked.init();
+  var config = baked.init({
+      options: {
+          ignore: [
+              'images/*',
+              'js/*',
+              'stylus/*'
+          ]
+      }
+  });
 
   // This example uses its specific package.json file so its gulp instance seems
   // to be distinct than the baked's one. This helper allows to load every tasks
@@ -101,7 +128,6 @@ gulp.task('stylus', function () {
 });
 gulp.task('watch:stylus', function () {
   gulp.watch(paths.stylus.src, ['stylus']);
-  gulp.watch('generated/*', ['reload']); //TODO: Figure out how to wait until backed:generate finishes so we don't have a ton of reloads while it's generating
 });
 
 //////////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-util": "^3.0.6",
     "gulp-watch": "^0.6.8",
     "imagemin-pngquant": "^4.1.2",
+    "run-sequence": "^1.1.2",
     "webpack-stream": "^2.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Browsersync should only reload the page once on changes that cannot be injected. Changes that can be injected (css, images) should be injected.